### PR TITLE
switch order of auto-embed options

### DIFF
--- a/suggest.ts
+++ b/suggest.ts
@@ -28,7 +28,7 @@ export default class EmbedSuggest extends EditorSuggest<IDateCompletion> {
 
 	getSuggestions(context: EditorSuggestContext): IDateCompletion[] {
 		// catch-all if there are no matches
-		return [{ choice: 'Dismiss' }, { choice: 'Create Embed' }];
+		return [{ choice: 'Create Embed' }, { choice: 'Dismiss' }];
 	}
 
 	renderSuggestion(suggestion: IDateCompletion, el: HTMLElement): void {


### PR DESCRIPTION
Related to this issue: https://github.com/Seraphli/obsidian-link-embed/issues/6

And this specific comment: https://github.com/Seraphli/obsidian-link-embed/issues/6#issuecomment-1264680051

Make this a "hit enter" instead of "down arrow + hit enter" to get auto-embed. This will hopefully make the workflow faster for the end user. 🤞 